### PR TITLE
avoid nvim_echo called in fast event

### DIFF
--- a/lua/sops.lua
+++ b/lua/sops.lua
@@ -25,13 +25,13 @@ local function sops_decrypt_buffer(bufnr)
     { "sops", "--decrypt", "--input-type", filetype, "--output-type", filetype, path },
     { cwd = cwd, text = true },
     function(out)
-      if out.code ~= 0 then
-        vim.notify("Failed to decrypt file", vim.log.levels.WARN)
-
-        return
-      end
-
       vim.schedule(function()
+        if out.code ~= 0 then
+          vim.notify("Failed to decrypt file", vim.log.levels.WARN)
+
+          return
+        end
+
         local decrypted_lines = vim.fn.split(out.stdout, "\n", false)
 
         -- Make this buffer writable only through our auto command


### PR DESCRIPTION
Without moving `vim.notify` to `vim.schdule`, I get the following error

```
vim/_editor.lua:0: E5560: nvim_echo must not be called in a fast event context
```