### PR TITLE
fix: only update fields that have changes

### DIFF
--- a/scripts/sops-editor.sh
+++ b/scripts/sops-editor.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# SOPS editor script for sops.nvim
+# This script copies the content from SOPS_NVIM_TEMP_FILE to the file specified by sops
+# Usage: SOPS_NVIM_TEMP_FILE=/path/to/temp/file sops-editor.sh /path/to/sops/temp/file
+
+# Credit for this hack goes to the vscode-sops extension.
+# https://github.com/signageos/vscode-sops/blob/9cc9a3f83a7328ec257ca7e5586b3b790b3f8410/src/extension.ts#L27-L32
+
+if [ -z "$SOPS_NVIM_TEMP_FILE" ]; then
+  echo "Error: SOPS_NVIM_TEMP_FILE environment variable not set" >&2
+  exit 1
+fi
+
+if [ ! -f "$SOPS_NVIM_TEMP_FILE" ]; then
+  echo "Error: SOPS_NVIM_TEMP_FILE does not exist: $SOPS_NVIM_TEMP_FILE" >&2
+  exit 1
+fi
+
+if [ -z "$1" ]; then
+  echo "Error: No target file specified" >&2
+  exit 1
+fi
+
+cat "$SOPS_NVIM_TEMP_FILE" >"$1"
+


### PR DESCRIPTION
There was a minor divergence in behavior when compared to vscode-sops.
We were re-encrypting the whole file, which did not give sops an
opportunity to diff the tree and elide changes to fields that had no
changes.

The vscode extension makes use of a neat hack by overriding the editor used by 'sops edit' to transplant the decrypted content over, which allows sops' tree diffing to work: https://github.com/signageos/vscode-sops/blob/9cc9a3f83a7328ec257ca7e5586b3b790b3f8410/src/extension.ts#L27-L32

Fixes #5
